### PR TITLE
always_include_dav_header typo

### DIFF
--- a/lib/dav4rack_ext/carddav/app.rb
+++ b/lib/dav4rack_ext/carddav/app.rb
@@ -32,50 +32,50 @@ module DAV4Rack
         end
 
         r.add("#{root_path}/").to DAV4RackExt::Handler.new(
-            :logger                   => logger,
-            :dav_extensions           => DAV_EXTENSIONS,
-            :alway_include_dav_header => true,
-            :pretty_xml               => true,
-            :root_uri_path            => root_uri_path,
-            :resource_class           => DAV4Rack::Carddav::PrincipalResource,
-            :controller_class         => DAV4Rack::Carddav::Controller,
-            :current_user             => current_user,
+            :logger                    => logger,
+            :dav_extensions            => DAV_EXTENSIONS,
+            :always_include_dav_header => true,
+            :pretty_xml                => true,
+            :root_uri_path             => root_uri_path,
+            :resource_class            => DAV4Rack::Carddav::PrincipalResource,
+            :controller_class          => DAV4Rack::Carddav::Controller,
+            :current_user              => current_user,
             
             # resource options
-            :books_collection         => "/books/"
+            :books_collection          => "/books/"
           )
         
         r.add("#{root_path}/books/").to DAV4RackExt::Handler.new(
-            :logger                   => logger,
-            :dav_extensions           => DAV_EXTENSIONS,
-            :alway_include_dav_header => true,
-            :pretty_xml               => true,
-            :root_uri_path            => root_uri_path,
-            :resource_class           => DAV4Rack::Carddav::AddressbookCollectionResource,
-            :controller_class         => DAV4Rack::Carddav::Controller,
-            :current_user             => current_user
+            :logger                    => logger,
+            :dav_extensions            => DAV_EXTENSIONS,
+            :always_include_dav_header => true,
+            :pretty_xml                => true,
+            :root_uri_path             => root_uri_path,
+            :resource_class            => DAV4Rack::Carddav::AddressbookCollectionResource,
+            :controller_class          => DAV4Rack::Carddav::Controller,
+            :current_user              => current_user
           )
         
         r.add("#{root_path}/books/:book_id/:contact_id(.vcf)").to DAV4RackExt::Handler.new(
-            :logger                   => logger,
-            :dav_extensions           => DAV_EXTENSIONS,
-            :alway_include_dav_header => true,
-            :pretty_xml               => true,
-            :root_uri_path            => root_uri_path,
-            :resource_class           => DAV4Rack::Carddav::ContactResource,
-            :controller_class         => DAV4Rack::Carddav::Controller,
-            :current_user             => current_user
+            :logger                    => logger,
+            :dav_extensions            => DAV_EXTENSIONS,
+            :always_include_dav_header => true,
+            :pretty_xml                => true,
+            :root_uri_path             => root_uri_path,
+            :resource_class            => DAV4Rack::Carddav::ContactResource,
+            :controller_class          => DAV4Rack::Carddav::Controller,
+            :current_user              => current_user
           )
         
         r.add("#{root_path}/books/:book_id").to DAV4RackExt::Handler.new(
-            :logger                   => logger,
-            :dav_extensions           => DAV_EXTENSIONS,
-            :alway_include_dav_header => true,
-            :pretty_xml               => true,
-            :root_uri_path            => root_uri_path,
-            :resource_class           => DAV4Rack::Carddav::AddressbookResource,
-            :controller_class         => DAV4Rack::Carddav::Controller,
-            :current_user             => current_user
+            :logger                    => logger,
+            :dav_extensions            => DAV_EXTENSIONS,
+            :always_include_dav_header  => true,
+            :pretty_xml                => true,
+            :root_uri_path             => root_uri_path,
+            :resource_class            => DAV4Rack::Carddav::AddressbookResource,
+            :controller_class          => DAV4Rack::Carddav::Controller,
+            :current_user              => current_user
           )
         
         # Another hack for iOS 6


### PR DESCRIPTION
I'm writing a caldav extension based on your carddav work, and noticed that your always_include_dav_header had a typo (alway_include_dav_header). This caused me some issues with iCal + CalDav.

By the way, as soon as I something stable out of my caldav code, I'll push to my repo and eventually perform a pull request into dav4rack_ext.
Cheers
